### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,7 @@
     "url": "https://github.com/Raynos/xtend/issues",
     "email": "raynos2@gmail.com"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/raynos/xtend/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "testling": {
     "files": "test.js",
     "browsers": [


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/