### PR TITLE
Support objects with no prototype

### DIFF
--- a/immutable.js
+++ b/immutable.js
@@ -1,5 +1,7 @@
 module.exports = extend
 
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
 function extend() {
     var target = {}
 
@@ -7,7 +9,7 @@ function extend() {
         var source = arguments[i]
 
         for (var key in source) {
-            if (source.hasOwnProperty(key)) {
+            if (hasOwnProperty.call(source, key)) {
                 target[key] = source[key]
             }
         }

--- a/mutable.js
+++ b/mutable.js
@@ -1,11 +1,13 @@
 module.exports = extend
 
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
 function extend(target) {
     for (var i = 1; i < arguments.length; i++) {
         var source = arguments[i]
 
         for (var key in source) {
-            if (source.hasOwnProperty(key)) {
+            if (hasOwnProperty.call(source, key)) {
                 target[key] = source[key]
             }
         }

--- a/test.js
+++ b/test.js
@@ -65,8 +65,8 @@ test("mutable", function (assert) {
 test("null prototype", function(assert) {
     var a = { a: "foo" }
     var b = Object.create(null)
-
     b.b = "bar";
+
     assert.deepEqual(extend(a, b), { a: "foo", b: "bar" })
     assert.end()
 })

--- a/test.js
+++ b/test.js
@@ -61,3 +61,23 @@ test("mutable", function (assert) {
     assert.equal(a.bar, "baz")
     assert.end()
 })
+
+test("null prototype", function(assert) {
+    var a = { a: "foo" }
+    var b = Object.create(null)
+
+    b.b = "bar";
+    assert.deepEqual(extend(a, b), { a: "foo", b: "bar" })
+    assert.end()
+})
+
+test("null prototype mutable", function (assert) {
+    var a = { foo: "bar" }
+    var b = Object.create(null)
+    b.bar = "baz";
+
+    mutableExtend(a, b)
+
+    assert.equal(a.bar, "baz")
+    assert.end()
+})


### PR DESCRIPTION
Currently `xtend` crashes when operation involves objects created via `Object.create(null)`