### PR TITLE
Make the immutable implementation reuse the mutable version's code

### DIFF
--- a/immutable.js
+++ b/immutable.js
@@ -1,19 +1,11 @@
+var mutableExtend = require('./mutable')
+
 module.exports = extend
 
-var hasOwnProperty = Object.prototype.hasOwnProperty;
-
 function extend() {
-    var target = {}
-
-    for (var i = 0; i < arguments.length; i++) {
-        var source = arguments[i]
-
-        for (var key in source) {
-            if (hasOwnProperty.call(source, key)) {
-                target[key] = source[key]
-            }
-        }
+    var args = [{}]
+    for (var i = 0; i < arguments.length; ++i) {
+        args.push(arguments[i])
     }
-
-    return target
+    return mutableExtend.apply(null, args)
 }


### PR DESCRIPTION
My main motivation is to save a few bytes in the Browserified apps where I use both the mutable and immutable versions.

Should still be ES3 compatible, shouldn't leak `arguments`.

I won't be offended if you think this change is silly and close it. :-)
