### PR TITLE
dropped Makefile added for obsolete browser compat build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-browser:
-	node ./support/compile
-
-.PHONY: browser


### PR DESCRIPTION
The compile.js script was already dropped. The stale Makefile was interfering with builds when I was trying to package the module for Debian.